### PR TITLE
added support for idFilter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+
+## [0.0.4] - 2015-04-13
+### Added 
+* Support for providers to filter queries with an idFilter param. This optional param is appended to the where clause and allows the query to filter on table id instead of property values. 
+
 ## [0.0.3] - 2015-04-11
 ### Changed 
 * Better logic for `<` or `>` operators in where clauses 
@@ -10,5 +15,6 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 * Created a new method for applying coded value domain from Esri services: applyCodedDomains - called when filtering data with fields that contain coded value domains
 
+[0.0.4]: https://github.com/Esri/koop-pgcache/compare/v0.0.3...v0.0.4
 [0.0.3]: https://github.com/Esri/koop-pgcache/compare/v0.0.2...v0.0.3
 [0.0.2]: https://github.com/Esri/koop-pgcache/compare/v0.0.1...v0.0.2

--- a/index.js
+++ b/index.js
@@ -267,6 +267,11 @@ module.exports = {
             } else {
               select += ' WHERE ' + options.where;
             }
+            if (options.idFilter){
+              select += ' AND ' + options.idFilter;
+            }
+          } else if (options.idFilter) {
+            select += ' WHERE ' + options.idFilter;
           }
 
           // parse the geometry param from GeoServices REST

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "koop-pgcache",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "A postgis cache for koop",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Adds the ability to the filter features in koop based on an optional idFilter param. Was going to stick with just passing in a where clause but with pgcache the where clause is being use to filter data on feature.properties in the JSON objects. This is need to filter on ids. 
