### PR TITLE
Issues with geom parsing when geoms are strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+### Fixed
+* Geometry objects passed in as strings were not correctly being parsed in the parseGeometry method.
+### Added 
+* better test coverage for parseGeometry
+
 ## [1.0.0] - 2015-06-15
 ### Added 
 * Created getExtent method that returns the extent of all features in the DB.

--- a/test/index.js
+++ b/test/index.js
@@ -312,18 +312,25 @@ describe('pgCache Model Tests', function () {
       done()
     })
 
+    it('should parse object geometries as strings', function (done) {
+      var input = '{"xmin":-15028131.257092925, "ymin":3291933.865166463, "xmax":-10018754.171396945, "ymax":8301310.950862443, "spatialReference":{"wkid":102100, "latestWkid":3857}}'
+      var geom = pgCache.parseGeometry(input)
+      geom.xmin.should.equal(-135.00000000000892)
+      done()
+    })
+
     it('should parse object geometries in 102100', function (done) {
       var input = {
-        xmin: -123.75,
-        ymin: 48.922499263758255,
-        xmax: -112.5,
-        ymax: 55.7765730186677,
+        xmin: -15028131.257092925,
+        ymin: 3291933.865166463,
+        xmax: -10018754.171396945,
+        ymax: 8301310.950862443,
         spatialReference: {
           wkid: 102100
         }
       }
       var geom = pgCache.parseGeometry(input)
-      geom.xmin.should.equal(-0.0011116651640979078)
+      geom.xmin.should.equal(-135.00000000000892)
       done()
     })
   })


### PR DESCRIPTION
added a test for objects passed in as strings and cleaned up the logic in parseGeometry to always re-project 102100 geoms to 4326.
