### PR TITLE
Host field too small, increased size GET

### DIFF
--- a/index.js
+++ b/index.js
@@ -689,7 +689,7 @@ module.exports = {
    */
   serviceRegister: function (type, info, callback) {
     var self = this
-    this._createTable(type, '(id varchar(100), host varchar(2048))', null, function (err, result) {
+    this._createTable(type, '(id varchar(100), host varchar)', null, function (err, result) {
       if (err) {
         callback(err)
       } else {

--- a/index.js
+++ b/index.js
@@ -689,7 +689,7 @@ module.exports = {
    */
   serviceRegister: function (type, info, callback) {
     var self = this
-    this._createTable(type, '(id varchar(100), host varchar(100))', null, function (err, result) {
+    this._createTable(type, '(id varchar(100), host varchar(2048))', null, function (err, result) {
       if (err) {
         callback(err)
       } else {


### PR DESCRIPTION
The host field contains most of the time URLs, therefore the field
should be able to contain urls with a length > 100 char, because
browsers and webservers limit URLs to 2KB (this may vary).
In a custom provider I'm working on, I use the host field to store even
more data about this host in json, and this exceeds 100 chars as well.
