### PR TITLE
add order by options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
+### Added
+* order_by option accepts array of {field: order} e.g. {'total_precip': 'ASC'}
+
 ### Changed
 * Stats are requested as float
 * Request data from the DB as JSON instead of strings

--- a/test/index.js
+++ b/test/index.js
@@ -128,6 +128,14 @@ describe('pgCache Model Tests', function () {
       })
     })
 
+    it('should select data from the db with a order by parameter', function (done) {
+      pgCache.select(key, {layer: 0, limit: 1, order_by: [{'total precip': 'DESC'}]}, function (error, success) {
+        should.not.exist(error)
+        success[0].features[0].properties['total precip'].should.equal(1.5)
+        done()
+      })
+    })
+
     it('should insert data with no features', function (done) {
       var snowKey = 'test:snow:data'
       pgCache.insert(snowKey, {name: 'no-data', geomType: 'Point', features: []}, 0, function (error, success) {


### PR DESCRIPTION
This PR allows order_by to be passed in as part of the options hash as an array of {field: order} objects.

cc @koopjs/dev
