### PR TITLE
add `getWKT` and `insertWKT` methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+### Added
+* New methods `getWKT` & `insertWKT` for storing and retrieving well known text strings of spatial reference systems
+
 ## [1.2.0] - 2015-09-10 
 ### Added
 * order_by option accepts array of {field: order} e.g. {'total_precip': 'ASC'}

--- a/index.js
+++ b/index.js
@@ -1036,6 +1036,45 @@ module.exports = {
     })
   },
 
+  /**
+   * Gets a WKT from the spatial_ref_sys table
+   *
+   * @param {integer} srid - the Spatial Reference ID
+   * @return {string} wkt - the well known text for the spatial reference system
+   */
+  getWKT: function (srid, callback) {
+    var self = this
+    var sql = 'SELECT srtext FROM spatial_ref_sys WHERE srid=' + srid + ';'
+    self._query(sql, function (err, result) {
+      if (err) return callback(err)
+      callback(null, self._extractWKT(result))
+    })
+  },
+
+  /**
+   * Wrap the return from getWKT so we can test the sql statement
+   *
+   * @param {object} result - response from the DB
+   * @return {string} - the body of the first row of the results
+   */
+  _extractWKT: function (result) {
+    return result.rows[0][0]
+  },
+
+  /**
+   * Inserts a WKT into the spatial_ref_sys table
+   *
+   * @param {integer} srid - the Spatial Reference ID
+   * @param {string} wkt - the well know ext for the spatial referfence system
+   */
+  insertWKT: function (srid, wkt, callback) {
+    var sql = 'INSERT INTO spatial_ref_sys (srid, srtext) VALUES (' + [srid, wkt].join(',') + ');'
+    this._query(sql, function (err, result) {
+      if (err) return callback(err)
+      callback(null, result)
+    })
+  },
+
   // ---------------
   // PRIVATE METHODS
   // ---------------

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "devDependencies": {
     "mocha": "^2.2.5",
     "should": "^4.6.1",
+    "sinon": "^1.16.1",
     "standard": "*",
     "winston": "^0.9.0"
   },


### PR DESCRIPTION
This PR adds two functions so that we can leverage the WKT strings for spatial references that are in PostGIS and add to them if we need to. There will be another PR coming in Koop to leverage these where needed.
