### PR TITLE
flatten info doc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## Unreleased
 ### Changed
 * Removed third parameter from _insertFeature as it was not being used for the id
+* Info passed in with geojson is stored as a flat object
+
+### Deprecated
+* Info passed in with geojson is no longer stored in the info doc as info.info
 
 ### Removed
 * deleted outdated docs folder (should only be committed to gh-pages)

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ var centroid = require('turf-centroid')
 var SM = require('sphericalmercator')
 var merc = new SM({ size: 256 })
 var pkg = require('./package')
+var _ = require('lodash')
 
 module.exports = {
   type: 'cache',
@@ -519,7 +520,10 @@ module.exports = {
    */
   insert: function (id, geojson, layerId, callback) {
     var self = this
-    var info = {}
+
+    var info = _.cloneDeep(geojson.info) || {}
+    // DEPRECATED: to be removed in 2.0
+    info.info = geojson.info
 
     info.name = geojson.name
     info.updated_at = geojson.updated_at
@@ -528,7 +532,6 @@ module.exports = {
     info.status = geojson.status
     info.format = geojson.format
     info.sha = geojson.sha
-    info.info = geojson.info
     info.host = geojson.host
 
     var table = id + ':' + layerId

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "url": "https://github.com/koopjs/koop-pgcache/issues"
   },
   "dependencies": {
+    "lodash": "^3.10.1",
     "ngeohash": "^0.6.0",
     "pg": "^4.2.0",
     "sphericalmercator": "^1.0.3",


### PR DESCRIPTION
This PR flattens the info doc that is created when an info object is passed on on geojson.

That object will now be stored directly as the resource's info doc.

Previously that info was stored on an info object of the info doc. That is now deprecated, with removal at 2.0.
