### PR TITLE
end broken transaction and retry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
+### Fixed
+* Aborted transactions are ended
+* Cleaned up some broken docs 
+
 ### Changed
 * Removed third parameter from _insertFeature as it was not being used for the id
 * Info passed in with geojson is stored as a flat object


### PR DESCRIPTION
This PR fixes an issue that occurs when tables are dropped during partial inserts. We end up in a situation where the last transaction was aboted and postgres will not accept any new requests.

A clause in `_query` catches this specific error code and retries the previous query. There is a guard parameter to prevent this from resulting in an endless loop.
