### PR TITLE
allow field indexing to be toggled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 * Removed third parameter from _insertFeature as it was not being used for the id
 * Info passed in with geojson is stored as a flat object
+* Indices set for each field can be turned off at insert time
 
 ### Deprecated
 * Info passed in with geojson is no longer stored in the info doc as info.info

--- a/index.js
+++ b/index.js
@@ -571,9 +571,12 @@ module.exports = {
       using: 'btree (substring(geohash,0,8))'
     }]
 
+    // in 2.0 we can pass in an option to decide whether to index fields, for now we will just use info
+    // default to true so there is no breaking change
+    if (typeof info._indexFields === 'undefined') info._indexFields = true
     // for each property in the data create an index
-    if (geojson.info && geojson.info.fields) {
-      geojson.info.fields.forEach(function (field) {
+    if (info && info.fields && info._indexFields) {
+      info.fields.forEach(function (field) {
         var idx = {
           name: field,
           using: 'btree ((feature->\'properties\'->>\'' + field + '\'))'


### PR DESCRIPTION
This PR allows the creation of b-tree indexes on every property to be toggled on and off. Two prevent this from being a breaking change, it uses a property called _indexFields on the geojson.info object that is passed in at table creation time.

In 2.0 we can allow options to be passed in to `insert` that allow this to be controlled more explicitly.
