### PR TITLE
add streaming export factory method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 *.log
 tags
 *.swp
+.vscode

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+### Added
+* `pgCache.createExportStream` returns a stream of features either as strings or JSON directly from the DB
+
 ## [1.5.1] - 2012-12-04
 ### Fixed
 * Test ensures success of idFilter

--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ var Table = require('./lib/table')
 var Geoservices = require('./lib/geoservices')
 var Geohash = require('./lib/geohash')
 var Select = require('./lib/select')
+var ExportStream = require('./lib/exportStream')
 
 module.exports = {
   type: 'cache',
@@ -55,6 +56,8 @@ module.exports = {
   insertPartial: Table.insertFeatures,
 
   geoHashAgg: Geohash.aggregate,
+
+  createExportStream: function (table, options) { return ExportStream.create(this.conn, table, options) },
 
   /**
    * Gets the count of all features in a table
@@ -171,7 +174,8 @@ module.exports = {
    */
   updateInfo: function (table, info, callback) {
     this.log.debug('Updating info %s %s', table, info.status)
-    this.query('update ' + this.infoTable + " set info = '" + JSON.stringify(info) + "' where id = '" + table + ":info'", function (err, result) {
+    var sql = 'update ' + this.infoTable + " set info = '" + JSON.stringify(info) + "' where id = '" + table + ":info'"
+    this.query(sql, function (err, result) {
       if (err || !result) {
         var error = new Error('Resource not found')
         error.table = table

--- a/lib/exportStream.js
+++ b/lib/exportStream.js
@@ -1,0 +1,39 @@
+var Geoservices = require('./geoservices')
+var spawn = require('child_process').spawn
+var _ = require('highland')
+
+/**
+ * Creates a stream that exports geojson from the database as a string
+ *
+ * @param {string} conn - psql connection string
+ * @param {string} table - the table to exports
+ * @param {object} options - includes which rows to export
+ */
+module.exports = {
+  create: function (conn, table, options) {
+    var dbStream = createDbStream(conn, table, options)
+    var jsonMode = options.json || 'string'
+    // rows coming from the DB are newline terminated, so we need to split and filter to get individual rows
+    var outStream = _(dbStream.stdout).split().reject(function (x) { return x.length < 1 })
+
+    dbStream.stderr.on('data', function (err) {
+      outStream.emit('error', err)
+    })
+    return jsonMode ? outStream.map(JSON.parse) : outStream
+  }
+}
+
+/**
+ * Creates the source db stream
+ *
+ * @param {string} conn - psql connection string
+ * @param {object} options - which rows to select
+ * @param {function} callback - calls back with an error or a stream from the db
+ * @private
+ */
+function createDbStream (conn, table, options) {
+  var where = Geoservices.parse(options)
+  var sql = 'copy (select feature from "' + table + '" ' + where + ') to stdout;'
+  var params = ['-c', sql, '-d', conn]
+  return spawn('psql', params)
+}

--- a/lib/geoservices.js
+++ b/lib/geoservices.js
@@ -33,7 +33,7 @@ Geoservices.parse = function (options) {
   parsed += addOrder(options)
   if (options.limit) parsed += ' LIMIT ' + options.limit
   if (options.offset) parsed += ' OFFSET ' + options.offset
-  return parsed
+  return parsed || ''
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "dependencies": {
     "async": "^1.5.0",
+    "highland": "^2.5.1",
     "lodash": "^3.10.1",
     "ngeohash": "^0.6.0",
     "pg": "^4.2.0",

--- a/test/index.js
+++ b/test/index.js
@@ -118,6 +118,23 @@ describe('pgCache Model Tests', function () {
       pgCache.select(key, { layer: 0 }, function (error, success) {
         should.not.exist(error)
         should.exist(success[0].features)
+        success[0].features.length.should.equal(417)
+        done()
+      })
+    })
+
+    it('should be able to stream data from the db', function (done) {
+      var exportStream = pgCache.createExportStream(key + ':' + 0, {json: true})
+      exportStream.toArray(function (features) {
+        features.length.should.equal(417)
+        done()
+      })
+    })
+
+    it('should be able to stream data from the db with filters', function (done) {
+      var exportStream = pgCache.createExportStream(key + ':' + 0, {where: '\'total precip\' = \'0.31\'', geometry: '-180,90,180,-90'})
+      exportStream.toArray(function (features) {
+        features.length.should.equal(5)
         done()
       })
     })


### PR DESCRIPTION
This PR adds new functionality to create a stream of features (as JSON or strings) that come directly from the DB. Under the hood it uses `psql` to execute a `copy` command and Highland.js to prepare each feature for consumption.

``` javascript
var options = { where: 'id > 10', json: true} // options include filter clauses and json vs string emittance
var stream = pgCache.createExportStream('tableName', options)
```
