### PR TITLE
Remove EXISTS query

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,9 @@ script:
 addons:
   postgresql: "9.6"
 
+
 before_script:
   - sudo apt-get -qq update
   - sudo apt-get install -y postgresql-9.6-postgis-2.4
-  - psql -U postgres -c 'create database test'
+  - psql -c 'create database koopdev;' -U postgres
   - psql -U postgres -d test -c 'create extension postgis'

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,11 @@ script:
   - npm test
 
 addons:
-  postgresql: "9.6"
+  postgresql: "9.3"
 
 
 before_script:
   - sudo apt-get -qq update
   - sudo apt-get install -y postgresql-9.6-postgis-2.4
   - psql -c 'create database koopdev;' -U postgres
-  - psql -U postgres -d test -c 'create extension postgis'
+  - psql -U postgres -d koopdev -c 'create extension postgis'

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ script:
   - npm test
 
 addons:
-  postgresql: "9.3"
+  postgresql: "9.6"
 
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,10 @@ script:
   - npm test
 
 addons:
-  postgresql: "9.3"
+  postgresql: "9.6"
 
 before_script:
-  - psql -c 'create database koopdev;' -U postgres
-  - psql -d koopdev -c 'create extension postgis;' -U postgres
+  - sudo apt-get -qq update
+  - sudo apt-get install -y postgresql-9.6-postgis-2.4
+  - psql -U postgres -c 'create database test'
+  - psql -U postgres -d test -c 'create extension postgis'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unrelease
+### Changed
+* Remove `EXISTS` query prior to table creation.
+
 ## [1.7.0] - 2016-03-20
 ### Added
 * Cache will retry initial connection if DB is not available

--- a/lib/exportStream.js
+++ b/lib/exportStream.js
@@ -16,12 +16,12 @@ module.exports = {
     // rows coming from the DB are newline terminated, so we need to split and filter to get individual rows
     var outStream = _()
     var featureStream = _(dbStream.stdout)
-    .split()
-    .compact()
-    // postgres does not properly ignore escaped double quotes
-    // the PSQL command accounts for this
-    // however this causes the entire feature to be wrapped in single quotes
-    .map(function (r) { return r.slice(1, -1) })
+      .split()
+      .compact()
+      // postgres does not properly ignore escaped double quotes
+      // the PSQL command accounts for this
+      // however this causes the entire feature to be wrapped in single quotes
+      .map(function (r) { return r.slice(1, -1) })
 
     dbStream.on('error', function (err) {
       outStream.emit('error', err)

--- a/lib/table.js
+++ b/lib/table.js
@@ -72,31 +72,26 @@ Table.createFeatureTable = function (id, geojson, layerId, callback) {
   })
 }
 
-  /**
-   * Creates a new table
-   * checks to see if the table exists, create it if not
-   *
-   * @param {string} name - the name of the index
-   * @param {string} schema - the schema to use for the table
-   * @param {Array} indexes - an array of indexes to place on the table
-   * @param {function} callback - the callback when the query returns
-   * @private
-   */
+/**
+ * Creates a new table
+ * checks to see if the table exists, create it if not
+ *
+ * @param {string} name - the name of the index
+ * @param {string} schema - the schema to use for the table
+ * @param {Array} indexes - an array of indexes to place on the table
+ * @param {function} callback - the callback when the query returns
+ * @private
+ */
 Table.create = function (name, schema, indexes, callback) {
   var self = this
   // set callback to noop if it hasn't been passed in
   callback = callback || function () {}
-  var sql = "select exists(select * from information_schema.tables where table_name='" + name + "')"
-  self.query(sql, function (err, result) {
-    if (err) return callback(new Error('Failed to create table ' + name))
-    if (result && result.rows[0].exists) return callback()
-    var create = 'CREATE TABLE "' + name + '" ' + schema
-    self.query(create, function (err, result) {
-      if (err) return callback(new Error('Failed to create table ' + name + ' error:' + err))
-      if (!indexes || !indexes.length) return callback()
-      Indexes._add(name, indexes, function (err) {
-        callback(err)
-      })
+  var create = 'CREATE TABLE "' + name + '" ' + schema
+  self.query(create, function (err, result) {
+    if (err) return callback(new Error('Failed to create table ' + name + ' error:' + err))
+    if (!indexes || !indexes.length) return callback()
+    Indexes._add(name, indexes, function (err) {
+      callback(err)
     })
   })
 }

--- a/lib/table.js
+++ b/lib/table.js
@@ -86,7 +86,7 @@ Table.create = function (name, schema, indexes, callback) {
   var self = this
   // set callback to noop if it hasn't been passed in
   callback = callback || function () {}
-  var create = 'CREATE TABLE "' + name + '" ' + schema
+  var create = 'CREATE TABLE IF NOT EXISTS "' + name + '" ' + schema
   self.query(create, function (err, result) {
     if (err) return callback(new Error('Failed to create table ' + name + ' error:' + err))
     if (!indexes || !indexes.length) return callback()

--- a/test/exportStream.js
+++ b/test/exportStream.js
@@ -5,12 +5,12 @@ var ExportStream = require('../lib/exportStream')
 describe('When creating an export stream', function () {
   it('should emit an error when postgres complains', function (done) {
     ExportStream.create('foo', 'foo', {})
-    .on('error', function (err) {
-      should.exist(err)
-      done()
-    })
-    .map(function (features) {
-      throw new Error('Fail')
-    })
+      .on('error', function (err) {
+        should.exist(err)
+        done()
+      })
+      .map(function (features) {
+        throw new Error('Fail')
+      })
   })
 })

--- a/test/index.js
+++ b/test/index.js
@@ -38,6 +38,22 @@ describe('pgCache Model Tests', function () {
         done()
       })
     })
+
+    it('Skip creating a table if it already exists - w/o erroring', function (done) {
+      var name = 'testtable2'
+      var schema = '(id varchar(100), feature json, geom Geometry(POINT, 4326))'
+      var indexes = []
+
+      Table.create(name, schema, indexes, function (err) {
+        should.not.exist(err)
+
+        Table.create(name, schema, indexes, function (err) {
+          should.not.exist(err)
+          done()
+        })
+      })
+    })
+
   })
 
   describe('when caching geojson', function () {


### PR DESCRIPTION
This PR removes the `SELECT EXISTS` query that occurs just before table creation.  It is somewhat unnecessary, because the table creation error, should it already exist, is handled after the `CREATE`.

The PR also includes some adjustments to pass `standard` formatting and an update to the travis.yml to fix broken postgis installation.